### PR TITLE
Configure allowed builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This triggers a job named `deploy_staging` defined in the Circle CI config file.
 ### Setup webhook
 
 * Payload URL: `https://URL/webhook`
+  * When you'd like to specify allowed jobs to trigger, append a comma-separated list of the jobs named `allowed_jobs` (e.g. `https://URL/webhook?allowed_jobs=test,deploy`)
 * Content type: `application/x-www-form-urlencoded`
 * Secret (Optional)
   * When you'd like to protect the app by verifying requests, specify a secret key.
@@ -27,3 +28,14 @@ This triggers a job named `deploy_staging` defined in the Circle CI config file.
   * Select `Let me select individual events.`
     * Issue comment
     * Pull request
+
+### Limit arbitrary jobs to trigger
+
+By default, every job can be triggered.
+
+But when you'd like to only allowed jobs, you have 2 options:
+
+* Set `GH_CIRCLE_TRIGGER_ALLOWED_JOBS` to environment variables
+  * This is the global configuration.
+* Set `allowed_jobs` as a query parameter
+  * This can be used as a repository-specific configuration. You can allow a different set of jobs for each repository.

--- a/app.json
+++ b/app.json
@@ -22,6 +22,10 @@
       "description": "When you'd like to protect the app by verifying requests, specify a secret key the same as webhook config on GitHub",
       "required": false
     },
+    "GH_CIRCLE_TRIGGER_ALLOWED_JOBS": {
+      "description": "Comma-separated list of jobs to trigger. Or yoy can specify it by a query parameter.",
+      "required": false
+    },
     "NPM_CONFIG_PRODUCTION": {
       "description": "This is to make it works properly on Heroku (don't modify).",
       "value": "false"

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -69,6 +69,20 @@ export default class Github {
     );
   }
 
+  async postJobNotAllowedMessage(
+    buildParam: BuildParameter,
+    allowedJobs: string[],
+  ) {
+    return this.postPullRequestComment(
+      buildParam.pullRequest,
+      'The job `' +
+        buildParam.job +
+        '` is not allowed to trigger.\n' +
+        'Allowed jobs are:\n\n' +
+        allowedJobs.map(job => `* ${job}`).join('\n'),
+    );
+  }
+
   private async get(url: string) {
     return axios.get<{ [keys: string]: any }>(url, this.requestConfig());
   }

--- a/src/Handler.test.ts
+++ b/src/Handler.test.ts
@@ -75,7 +75,7 @@ describe('handler', () => {
         });
 
         it('returns the triggered job', async () => {
-          const result = await handler.handle(event);
+          const result = await handler.handle(event, []);
 
           expect(result).toEqual('Trigger: the_job, Branch: fix');
         });
@@ -97,7 +97,7 @@ describe('handler', () => {
         });
 
         it('throws an error', async () => {
-          const err = await handler.handle(event).catch(err => err);
+          const err = await handler.handle(event, []).catch(err => err);
 
           expect(err.message).toEqual('Request failed with status code 403');
         });
@@ -105,7 +105,7 @@ describe('handler', () => {
     });
 
     describe('when it does not contain trigger word', async () => {
-      const result = await handler.handle(event);
+      const result = await handler.handle(event, []);
 
       expect(result).toEqual('NOOP');
     });
@@ -184,7 +184,7 @@ describe('handler', () => {
         });
 
         it('returns the triggered job', async () => {
-          const result = await handler.handle(event);
+          const result = await handler.handle(event, []);
 
           expect(result).toEqual('Trigger: the_job, Branch: fix');
         });
@@ -206,7 +206,7 @@ describe('handler', () => {
         });
 
         it('throws an error', async () => {
-          const err = await handler.handle(event).catch(err => err);
+          const err = await handler.handle(event, []).catch(err => err);
 
           expect(err.message).toEqual('Request failed with status code 403');
         });
@@ -214,7 +214,7 @@ describe('handler', () => {
     });
 
     describe('when it does not contain trigger word', async () => {
-      const result = await handler.handle(event);
+      const result = await handler.handle(event, []);
 
       expect(result).toEqual('NOOP');
     });
@@ -229,7 +229,7 @@ describe('handler', () => {
     };
 
     it('returns NOOP', async () => {
-      const result = await handler.handle(event);
+      const result = await handler.handle(event, []);
 
       expect(result).toEqual('NOOP');
     });

--- a/src/Handler.test.ts
+++ b/src/Handler.test.ts
@@ -79,6 +79,24 @@ describe('handler', () => {
 
           expect(result).toEqual('Trigger: the_job, Branch: fix');
         });
+
+        describe('when allowedJobs is not empty', () => {
+          describe('and the job is in allowedJobs', async () => {
+            it('returns the triggered job', async () => {
+              const result = await handler.handle(event, ['the_job']);
+
+              expect(result).toEqual('Trigger: the_job, Branch: fix');
+            });
+          });
+
+          describe('and the job is not in allowedJobs', async () => {
+            it('returns the triggered job', async () => {
+              const result = await handler.handle(event, ['not_the_job']);
+
+              expect(result).toEqual('Not allowed: the_job');
+            });
+          });
+        });
       });
 
       describe('and it failed to trigger the job', () => {
@@ -187,6 +205,24 @@ describe('handler', () => {
           const result = await handler.handle(event, []);
 
           expect(result).toEqual('Trigger: the_job, Branch: fix');
+        });
+
+        describe('when allowedJobs is not empty', () => {
+          describe('and the job is in allowedJobs', async () => {
+            it('returns the triggered job', async () => {
+              const result = await handler.handle(event, ['the_job']);
+
+              expect(result).toEqual('Trigger: the_job, Branch: fix');
+            });
+          });
+
+          describe('and the job is not in allowedJobs', async () => {
+            it('returns the triggered job', async () => {
+              const result = await handler.handle(event, ['not_the_job']);
+
+              expect(result).toEqual('Not allowed: the_job');
+            });
+          });
         });
       });
 

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -18,7 +18,7 @@ export default class Handler {
   ): Promise<string> {
     const buildParam = await this.github.paraseBuildParameter(event);
     if (buildParam && buildParam.job) {
-      if (allowedJobs.find(job => job === buildParam.job)) {
+      if (this.isNotAllowed(buildParam.job, allowedJobs)) {
         await this.github.postJobNotAllowedMessage(buildParam, allowedJobs);
         return `Not allowed: ${buildParam.job}`;
       }
@@ -35,6 +35,13 @@ export default class Handler {
     }
 
     return 'NOOP';
+  }
+
+  private isNotAllowed(job: string, allowedJobs: string[]): boolean {
+    return (
+      allowedJobs.length > 0 &&
+      !allowedJobs.find(allowedJob => allowedJob === job)
+    );
   }
 
   private async postErrorMessageToGithub(

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ export interface Config {
   githubAccessToken: string;
   circleApiToken: string;
   triggerWord: string;
+  allowedJobs?: string;
 }
 
 export const loadConfig = (): Config => {
@@ -21,5 +22,6 @@ export const loadConfig = (): Config => {
     githubAccessToken: process.env.GITHUB_ACCESS_TOKEN,
     circleApiToken: process.env.CIRCLE_API_TOKEN,
     triggerWord: process.env.GH_CIRCLE_TRIGGER_TRIGGER_WORD,
+    allowedJobs: process.env.GH_CIRCLE_TRIGGER_ALLOWED_JOBS,
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ app.post('/webhook', async (req: RequestWithRawBody, res: Response) => {
     }
 
     const event = loadWebhookEvent(req);
-    const result = await handler.handle(event);
+    const result = await handler.handle(event, []);
     res.send(result);
   } catch (err) {
     const error = ensureError(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import Circleci from './Circleci';
 import { loadConfig } from './config';
 import Github, { loadWebhookEvent } from './Github';
 import Handler from './Handler';
-import { decode, ensureError, isInvalidSignature } from './utils';
+import { allowedJobs, decode, ensureError, isInvalidSignature } from './utils';
 
 const app = express();
 const config = loadConfig();
@@ -55,7 +55,10 @@ app.post('/webhook', async (req: RequestWithRawBody, res: Response) => {
     }
 
     const event = loadWebhookEvent(req);
-    const result = await handler.handle(event, []);
+    const result = await handler.handle(
+      event,
+      allowedJobs(config.allowedJobs, req.query.allowed_jobs),
+    );
     res.send(result);
   } catch (err) {
     const error = ensureError(err);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { isInvalidSignature } from './utils';
+import { allowedJobs, isInvalidSignature } from './utils';
 
 describe('utils', () => {
   describe('isInvalidSignature', () => {
@@ -37,6 +37,31 @@ describe('utils', () => {
             ),
           ).toBe(true);
         });
+      });
+    });
+  });
+
+  describe('allowedJobs', () => {
+    describe('when both of them are not specified', () => {
+      it('returns an empty array', () => {
+        expect(allowedJobs(undefined, undefined)).toEqual([]);
+      });
+    });
+
+    describe('when both of them are specified', () => {
+      it('returns an array of fromQuery', () => {
+        expect(allowedJobs('a,b,c', 'd,e,f')).toEqual(['d', 'e', 'f']);
+      });
+    });
+
+    describe('when only fromConfig is specified', () => {
+      it('returns an array of fromConfig', () => {
+        expect(allowedJobs('a,b,c', undefined)).toEqual(['a', 'b', 'c']);
+      });
+    });
+    describe('when only fromQuery is specified', () => {
+      it('returns an array of fromQuery', () => {
+        expect(allowedJobs(undefined, 'd,e,f')).toEqual(['d', 'e', 'f']);
       });
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,3 +46,17 @@ export const decode = (url: string | undefined): string => {
 
   return decodeURIComponent(url.replace(/\+/g, ' '));
 };
+
+export const allowedJobs = (
+  fromConfig: string | undefined,
+  fromQuery: string | undefined,
+): string[] => {
+  if (typeof fromQuery === 'string') {
+    return fromQuery.split(',');
+  }
+  if (typeof fromConfig === 'string') {
+    return fromConfig.split(',');
+  }
+
+  return [];
+};


### PR DESCRIPTION
ref: https://github.com/yuya-takeyama/gh-circle-trigger/issues/6

### Limit arbitrary jobs to trigger

By default, every job can be triggered.

But when you'd like to only allowed jobs, you have 2 options:

* Set `GH_CIRCLE_TRIGGER_ALLOWED_JOBS` to environment variables
  * This is the global configuration.
* Set `allowed_jobs` as a query parameter
  * This can be used as a repository-specific configuration. You can allow a different set of jobs for each repository.